### PR TITLE
画像ドメイン許可 #29

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "imgfp.hotp.jp",
       },
+      {
+        protocol: "http",
+        hostname: "imgfp.hotp.jp",
+      },
     ],
   },
 };


### PR DESCRIPTION
## 概要
ホットペッパーの画像のドメインを許可設定
## 理由
<Image> コンポーネント（next/image）は、外部の画像を自動で最適化（リサイズ・フォーマット変換・キャッシュ）してくれますが、セキュリティ上の理由から、許可されたドメインの画像しか処理しないから