### PR TITLE
ホットペッパーエラーレスポンスを追加 #33

### DIFF
--- a/frontend/src/features/restaurant/types/HotPepper.ts
+++ b/frontend/src/features/restaurant/types/HotPepper.ts
@@ -35,7 +35,7 @@ export interface HotPepperResponse {
 /** results 直下の構造 */
 export interface HotPepperResults {
     api_version: string;
-    error?: HotPepperError[];
+    error?: HotPepperError;
     results_available: number;
     results_returned: number;
     results_start: number;

--- a/frontend/src/lib/hotpepper.ts
+++ b/frontend/src/lib/hotpepper.ts
@@ -26,10 +26,10 @@ const ERROR_MESSAGES: Record<number, string> = {
  * HTTP ステータスは常に 200 のため、レスポンスボディで判定する。
  */
 export function throwIfHotPepperError(response: HotPepperResponse): void {
-  const errors = response.results.error;
-  if (!errors || errors.length === 0) return;
+  const error = response.results.error;
+  if (!error) return;
 
-  const { code, message } = errors[0];
+  const { code, message } = error;
   const description = ERROR_MESSAGES[code] ?? "不明なエラーが発生しました。";
   throw new Error(`${description}（code: ${code}, message: ${message}）`);
 }


### PR DESCRIPTION
## 概要
ホットペッパーエラーレスポンスを追加
## 内容
ホットペッパーのAPIで提示されているレスポンスを適切に受け取るために、エラー処理を追加
1000：サーバ障害エラー
2000：APIキーまたはIPアドレスの認証エラー
3000：パラメータ不正エラー
