### PR TITLE
現在地取得失敗の際の表示を追加 #54

### DIFF
--- a/frontend/src/constants/app.ts
+++ b/frontend/src/constants/app.ts
@@ -43,6 +43,9 @@ export type SearchRangeValue = typeof SEARCH_RANGE_OPTIONS[number]['value'];
 // デフォルトの検索範囲
 export const DEFAULT_SEARCH_RANGE: SearchRangeValue = 3 as const;
 
+// デフォルトの検索範囲のメートル数
+export const DEFAULT_SEARCH_RANGE_METERS = 1000 as const;
+
 // ================================================================
 // 認証
 // ================================================================

--- a/frontend/src/features/restaurant/components/SearchForm.tsx
+++ b/frontend/src/features/restaurant/components/SearchForm.tsx
@@ -11,6 +11,7 @@ import {
   SEARCH_RANGE_OPTIONS,
   DEFAULT_SEARCH_RANGE,
   type SearchRangeValue,
+  DEFAULT_SEARCH_RANGE_METERS,
 } from "@/constants/app";
 
 const SearchMap = dynamic(
@@ -69,7 +70,7 @@ export default function SearchForm() {
 
   // 検索範囲のメートル数を取得
   const radiusMeters =
-    SEARCH_RANGE_OPTIONS.find((opt) => opt.value === range)?.meters ?? 1000;
+    SEARCH_RANGE_OPTIONS.find((opt) => opt.value === range)?.meters ?? DEFAULT_SEARCH_RANGE_METERS;
 
   return (
     <div className="mx-auto max-w-2xl px-5 py-8">


### PR DESCRIPTION
## 概要
現在地取得失敗の際の表示を追加
## 内容
geoloctionで現在地を取得できなかった場合にデフォルトで入れている東京駅を基準に検索できるように追加
