### PR TITLE
ボタンを押した際にスピナーがlgで実行されるためサイズを変更してスピナーを実行 #74

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -29,6 +29,12 @@ const sizeStyles: Record<ButtonSize, string> = {
   lg: "px-8 py-4 text-base rounded-2xl",
 };
 
+const spinnerSizeMap: Record<ButtonSize, "sm" | "md"> = {
+  sm: "sm",
+  md: "sm",
+  lg: "md",
+};
+
 export function Button({
   variant = "primary",
   size = "md",
@@ -58,7 +64,7 @@ export function Button({
       disabled={disabled || isLoading}
       {...props}
     >
-      {isLoading && <Spinner size={size} />}
+      {isLoading && <Spinner size={spinnerSizeMap[size]} />}
       {children}
     </button>
   );


### PR DESCRIPTION
## 概要
ボタンを押した際にスピナーがlgで実行されるためサイズを変更してスピナーを実行
## 内容
ボタンのサイズそのままをスピナーコンポーネントに送っていたため、spinnerSizeMapでlgをmdに変換してから、スピナーコンポーネントに送る