### PR TITLE
スクロールバーが常にある状態にしてレイアウトを調整 #81

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -23,6 +23,11 @@
   --font-sans: var(--font-noto-sans-jp);
 }
 
+html {
+  scrollbar-gutter: stable;
+  overflow-y: scroll;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);


### PR DESCRIPTION
## 概要
スクロールバーが常にある状態にしてレイアウトを調整
## 内容
```
scrollbar-gutter: stable;
overflow-y: scroll;
```
上記を追加して、スクロールバーアリのレイアウト調整をして、スクロールバーは常に表示に変更