### PR TITLE
予算とアクセスを横並びに変更 #79

### DIFF
--- a/frontend/src/components/elements/RestaurantCard.tsx
+++ b/frontend/src/components/elements/RestaurantCard.tsx
@@ -56,7 +56,7 @@ export function RestaurantCard({ restaurant, className }: RestaurantCardProps) {
         </div>
 
         {/* 予算・アクセス */}
-        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+        <div className="mt-2 flex flex-col gap-x-4 gap-y-1 text-xs text-gray-500">
           {budgetName && (
             <span className="flex items-center gap-1">
               <WalletIcon />


### PR DESCRIPTION
## 概要
予算とアクセスを横並びに変更
## 内容
アクセス文字列が長くなるとレイアウトが崩れていたため横並びに変更