### PR TITLE
列表示に変更してgapのxが必要ではなくなったため #91

### DIFF
--- a/frontend/src/components/elements/RestaurantCard.tsx
+++ b/frontend/src/components/elements/RestaurantCard.tsx
@@ -56,7 +56,7 @@ export function RestaurantCard({ restaurant, className }: RestaurantCardProps) {
         </div>
 
         {/* 予算・アクセス */}
-        <div className="mt-2 flex flex-col gap-x-4 gap-y-1 text-xs text-gray-500">
+        <div className="mt-2 flex flex-col gap-y-1 text-xs text-gray-500">
           {budgetName && (
             <span className="flex items-center gap-1">
               <WalletIcon />


### PR DESCRIPTION
## 概要
不要なcssを削除
## 内容
前回の変更で列表示に変更しました。その際に、gapのｘは不要であり、削除をし忘れていたため。
今回変更した